### PR TITLE
Add github-templates (for this repo and generated projects)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: status:undecided, type:bug
+assignees: BurningEnlightenment
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior or a minimal (if possible self contained) reproducing code snippet.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Environment**
+ - OS: [e.g. Debian 11.1]
+ - Project Version: [e.g. commit hash or release tag]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,7 @@ name: Bug report
 about: Create a report to help us improve
 title: ''
 labels: status:undecided, type:bug
-assignees: BurningEnlightenment
+assignees: ''
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,7 +3,7 @@ name: Feature request
 about: Suggest an idea for this project
 title: ''
 labels: status:undecided, type:task
-assignees: BurningEnlightenment
+assignees: ''
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: status:undecided, type:task
+assignees: BurningEnlightenment
+
+---
+
+**Problem Description**
+<!-- Is your feature request related to a problem? -->
+Add a clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Proposed Solution**
+<!-- Describe the solution you'd like -->
+A clear and concise description of what you want to happen.
+
+**Possible Alternative Approaches**
+<!-- Describe alternatives you've considered -->
+A clear and concise description of any alternative solutions or features you've considered and how they differ from your preferred solution.
+
+**Additional Context**
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,10 @@
+---
+name: Question
+about: Ask a question regarding this project.
+title: ''
+labels: status:undecided, type:question
+assignees: ''
+
+---
+
+

--- a/tmpl/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/tmpl/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: status:undecided, type:bug
+assignees: BurningEnlightenment
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior or a minimal (if possible self contained) reproducing code snippet.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Environment**
+ - OS: [e.g. Debian 11.1]
+ - Project Version: [e.g. commit hash or release tag]
+
+**Additional context**
+Add any other context about the problem here.

--- a/tmpl/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/tmpl/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,7 @@ name: Bug report
 about: Create a report to help us improve
 title: ''
 labels: status:undecided, type:bug
-assignees: BurningEnlightenment
+assignees: ''
 
 ---
 

--- a/tmpl/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/tmpl/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,7 +3,7 @@ name: Feature request
 about: Suggest an idea for this project
 title: ''
 labels: status:undecided, type:task
-assignees: BurningEnlightenment
+assignees: ''
 
 ---
 

--- a/tmpl/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/tmpl/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: status:undecided, type:task
+assignees: BurningEnlightenment
+
+---
+
+**Problem Description**
+<!-- Is your feature request related to a problem? -->
+Add a clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Proposed Solution**
+<!-- Describe the solution you'd like -->
+A clear and concise description of what you want to happen.
+
+**Possible Alternative Approaches**
+<!-- Describe alternatives you've considered -->
+A clear and concise description of any alternative solutions or features you've considered and how they differ from your preferred solution.
+
+**Additional Context**
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/tmpl/.github/ISSUE_TEMPLATE/question.md
+++ b/tmpl/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,10 @@
+---
+name: Question
+about: Ask a question regarding this project.
+title: ''
+labels: status:undecided, type:question
+assignees: ''
+
+---
+
+


### PR DESCRIPTION
This repository has no github issue templates.
The templates are also added to the template itself.

The issue templates are copied from concrete.